### PR TITLE
Add clipboard manipulations

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Mack is ideal for local workflow optimization, OS X binary applications, or just
 
 ### Workflow: Process notification
 When executing a long-running process, trigger a notification so you can get back to development without having to check the execution status.
-```
+```go
 package main
 
 import "github.com/everdev/mack"
@@ -25,7 +25,7 @@ func main() {
 
 ### Workflow: Open applications
 Interact with any Mac application from your code, like opening a URL to a HowTo video.
-```
+```go
 package main
 
 import (
@@ -55,7 +55,7 @@ func main() {
 
 ### App: ToDo list
 Add a cheap GUI to your applications
-```
+```go
 package main
 
 import "github.com/everdev/mack"
@@ -71,14 +71,37 @@ func main() {
   } else {
     newToDo := response.Text
     // add ToDo to the database
-    mack.Notify("Added " + newToDo + " to your calendar")  
+    mack.Notify("Added " + newToDo + " to your calendar")
   }
+}
+```
+
+### Workflow: clipboard
+Manipulate the clipboard
+```go
+package main
+
+import (
+  "fmt"
+  "github.com/everdev/mack"
+)
+
+func main() {
+  // Output the content of the clipboard
+  content, _ := mack.Clipboard()
+  fmt.Println(content)
+
+  // Change the content of the clipboard
+  mack.SetClipboard("Hello World!")
+  content, _ = mack.Clipboard()
+  fmt.Println(content)
 }
 ```
 
 ## Documentation
 Currently, Mack supports the following AppleScript commands:
 * Beep
+* Clipboard
 * Display Alert
 * Display Dialog
 * Display Notification
@@ -93,6 +116,7 @@ Full documentation is available at: [godoc.org/github.com/everdev/mack](http://g
 ## Contributors
 * Andy Brewer ([everdev](https://github.com/everdev))
 * Hiroaki Nakamura ([hnakamur](https://github.com/hnakamur))
+* Antoine Augusti ([AntoineAugusti](https://github.com/AntoineAugusti))
 
 ## License
 MIT

--- a/clipboard.go
+++ b/clipboard.go
@@ -1,0 +1,28 @@
+/*
+** Mack: Clipboard
+** Interact with the clipboard
+ */
+
+package mack
+
+// Clipboard returns the content of the clipboard
+func Clipboard() (string, error) {
+	return run(buildClipboard())
+}
+
+// Build the command
+func buildClipboard() string {
+	return build("the clipboard")
+}
+
+// SetClipboard changes the content of the clipboard
+func SetClipboard(content string) error {
+	_, err := run(buildSetClipboard(content))
+	return err
+}
+
+// Wrap the content in quotes and build the command
+func buildSetClipboard(content string) string {
+	content = wrapInQuotes(content)
+	return build("set the clipboard to", content)
+}

--- a/clipboard_test.go
+++ b/clipboard_test.go
@@ -1,0 +1,47 @@
+/*
+** Mack: Clipboard
+** Interact with the clipboard
+ */
+
+package mack
+
+import (
+	"testing"
+)
+
+func TestBuildClipboard(t *testing.T) {
+	stringAssertTests := []StringAssert{
+		StringAssert{
+			actual:   buildClipboard(),
+			expected: "the clipboard",
+		},
+	}
+
+	runStringAssertTests("buildClipboard", stringAssertTests, t)
+}
+
+func TestBuildSetClipboard(t *testing.T) {
+	stringAssertTests := []StringAssert{
+		StringAssert{
+			actual:   buildSetClipboard("text"),
+			expected: "set the clipboard to \"text\"",
+		},
+	}
+
+	runStringAssertTests("buildSetClipboard", stringAssertTests, t)
+}
+
+func TestSetClipboard(t *testing.T) {
+	content := "testing clipboard"
+	SetClipboard(content)
+	result, _ := Clipboard()
+
+	stringAssertTests := []StringAssert{
+		StringAssert{
+			actual:   result,
+			expected: content,
+		},
+	}
+
+	runStringAssertTests("buildSetClipboard", stringAssertTests, t)
+}


### PR DESCRIPTION
This PR adds support for getting the content of the clipboard / setting the content of the clipboard.

I've ran the tests with the command `go test -v -race $(go list ./...)`. It would be a good idea to set up some form of CI like https://travis-ci.org. I can submit another PR if you want :)
