### PR TITLE
Fix parsing of dialog button response

### DIFF
--- a/mack.go
+++ b/mack.go
@@ -1,7 +1,7 @@
 /*
 ** Mack
 ** A wrapper for AppleScript
-*/
+ */
 
 // Mack is a Golang wrapper for AppleScript. With Mack, you can easily trigger
 // OS X desktop notifications and system sounds from within your Go application.
@@ -11,131 +11,132 @@
 package mack
 
 import (
-  "regexp"
-  "errors"
-  "os/exec"
-  "strings"
+	"errors"
+	"os/exec"
+	"regexp"
+	"strings"
 )
 
 // Build the AppleScript command from a set of optional parameters, return the output
 func run(command string) (string, error) {
-  cmd := exec.Command("osascript", "-e", command)
-  output, err := cmd.CombinedOutput()
-  prettyOutput := strings.Replace(string(output), "\n", "", -1)
+	cmd := exec.Command("osascript", "-e", command)
+	output, err := cmd.CombinedOutput()
+	prettyOutput := strings.Replace(string(output), "\n", "", -1)
 
-  // Ignore errors from the user hitting the cancel button
-  if err != nil && strings.Index(string(output), "User canceled.") < 0 {
-    return "", errors.New(err.Error() + ": " + prettyOutput + " (" + command + ")")
-  }
+	// Ignore errors from the user hitting the cancel button
+	if err != nil && strings.Index(string(output), "User canceled.") < 0 {
+		return "", errors.New(err.Error() + ": " + prettyOutput + " (" + command + ")")
+	}
 
-  return prettyOutput, nil
+	return prettyOutput, nil
 }
 
 // Build the AppleScript command from a set of optional parameters, return a Response
 func runWithButtons(command string) (Response, error) {
-  output, err := run(command)
+	output, err := run(command)
 
-  // Return if the user hit the default cancel button
-  if strings.Index(output, "execution error: User canceled. (-128)") > 0 {
-    response := Response{
-      Clicked: "Cancel",
-    }
-    return response, err
-  }
+	// Return if the user hit the default cancel button
+	if strings.Index(output, "execution error: User canceled. (-128)") > 0 {
+		response := Response{
+			Clicked: "Cancel",
+		}
+		return response, err
+	}
 
-  // Parse the buttons
-  re := regexp.MustCompile("buttons {(.*)}")
-  buttonMatches := re.FindStringSubmatch(command)
-  var buttons []string
-  if len(buttonMatches) > 1 {
-    buttons = strings.Split(buttonMatches[1], ",")
-  } else {
-    buttons = []string{"OK","Cancel"}
-  }
+	// Parse the buttons
+	re := regexp.MustCompile("buttons {(.*)}")
+	buttonMatches := re.FindStringSubmatch(command)
+	var buttons []string
+	if len(buttonMatches) > 1 {
+		buttons = strings.Split(buttonMatches[1], ",")
+	} else {
+		buttons = []string{"OK", "Cancel"}
+	}
 
-  return parseResponse(output, buttons), err
+	return parseResponse(output, buttons), err
 }
 
 // Wrap text in quotes for proper command line formatting
 func wrapInQuotes(text string) string {
-  return "\"" + text + "\""
+	return "\"" + text + "\""
 }
 
 // Build the AppleScript command, ignoring any blank optional parameters
 func build(params ...string) string {
-  var validParams []string
+	var validParams []string
 
-  for _, param := range params {
-    if param != "" {
-      validParams = append(validParams, param)
-    }
-  }
+	for _, param := range params {
+		if param != "" {
+			validParams = append(validParams, param)
+		}
+	}
 
-  return strings.Join(validParams, " ")
+	return strings.Join(validParams, " ")
 }
 
 // Parse and format the button values
 func makeButtonList(buttons string) string {
-  buttonList := strings.Split(buttons, ",")
+	buttonList := strings.Split(buttons, ",")
 
-  if len(buttonList) > 3 {
-    buttonList = buttonList[:3]
-  }
+	if len(buttonList) > 3 {
+		buttonList = buttonList[:3]
+	}
 
-  var wrappedButtons []string
-  for _, button := range buttonList {
-    wrappedButtons = append(wrappedButtons, wrapInQuotes(strings.TrimSpace(button)))
-  }
+	var wrappedButtons []string
+	for _, button := range buttonList {
+		wrappedButtons = append(wrappedButtons, wrapInQuotes(strings.TrimSpace(button)))
+	}
 
-  return "buttons {" + strings.Join(wrappedButtons, ",") + "}"
+	return "buttons {" + strings.Join(wrappedButtons, ",") + "}"
 }
 
 // Parse a button response
 func parseResponse(output string, buttons []string) Response {
-  var clicked, text string
-  var gaveUp bool
+	var clicked, text string
+	var gaveUp bool
 
-  // Find out if the notification gave up
-  gaveUpRe := regexp.MustCompile("gave up:(true|false)")
-  gaveUpMatches := gaveUpRe.FindStringSubmatch(output)
-  if len(gaveUpMatches) > 1 && gaveUpMatches[1] == "true" {
-    gaveUp = true
-  }
+	// Find out if the notification gave up
+	gaveUpRe := regexp.MustCompile("gave up:(true|false)")
+	gaveUpMatches := gaveUpRe.FindStringSubmatch(output)
+	if len(gaveUpMatches) > 1 && gaveUpMatches[1] == "true" {
+		gaveUp = true
+	}
 
-  if !gaveUp {
-    for _, button := range buttons {
-      // Find which button was clicked
-      buttonStr := "button returned:" + button
-      clickedRe := regexp.MustCompile(buttonStr + ",")
-      if clickedRe.MatchString(output) || output == buttonStr {
-        clicked = button
-        break
-      }
-    }
+	if !gaveUp {
+		for _, button := range buttons {
+			// Find which button was clicked
+			button = strings.Trim(button, `"`)
+			buttonStr := "button returned:" + button
+			clickedRe := regexp.MustCompile(buttonStr + ",")
+			if clickedRe.MatchString(output) || output == buttonStr {
+				clicked = button
+				break
+			}
+		}
 
-    // Don't mess around with regex, just get the text returned
-    if strings.Index(output, ", text returned:") > 0 {
-      output = strings.Replace(output, "button returned:" + clicked + ", ", "", 1)
-      output = strings.Replace(output, ", gave up:false", "", 1)
-      output = strings.Replace(output, "text returned:", "", 1)
-      text = output
-    }
-  }
+		// Don't mess around with regex, just get the text returned
+		if strings.Index(output, ", text returned:") > 0 {
+			output = strings.Replace(output, "button returned:"+clicked+", ", "", 1)
+			output = strings.Replace(output, ", gave up:false", "", 1)
+			output = strings.Replace(output, "text returned:", "", 1)
+			text = output
+		}
+	}
 
-  // Find out if the user entered text
+	// Find out if the user entered text
 
-  response := Response{
-    Clicked: clicked,
-    GaveUp: gaveUp,
-    Text: text,
-  }
+	response := Response{
+		Clicked: clicked,
+		GaveUp:  gaveUp,
+		Text:    text,
+	}
 
-  return response
+	return response
 }
 
 // The response format after a button click on an alert or dialog box
 type Response struct {
-  Clicked string  // The name of the button clicked
-  GaveUp bool     // True if the user failed to respond in the duration specified
-  Text string     // Only on Dialog boxes - The return value of the input field
+	Clicked string // The name of the button clicked
+	GaveUp  bool   // True if the user failed to respond in the duration specified
+	Text    string // Only on Dialog boxes - The return value of the input field
 }


### PR DESCRIPTION
Buttons that are explicitly defined using the DialogOptions struct are
wrapped in quotes; ensure those are stripped during parsing so that
they're correctly matched against the response

Note: this is a 1 line change to line 108 of `mack.go`; gofmt introduced more
whitespace changes on file save.

Adding `&w=1` to the github diff view page will filter out all the whitespace change noise