### PR TITLE
fix for providing an icon path in POSIX format

### DIFF
--- a/dialog.go
+++ b/dialog.go
@@ -1,114 +1,116 @@
 /*
 ** Mack: Alert
 ** Create a desktop dialog box
-*/
+ */
 
 package mack
 
 import (
-  "strconv"
-  "strings"
+	"strconv"
+	"strings"
 )
 
 // Dialog triggers a desktop dialog box. Either an error is returned, or the string output from the user interaction.
-//  mack.Dialog("Dialog text")                                    // Display a dialog box
-//  mack.Dialog("Dialog text", "My Title")                        // Display a dialog box with the title "My Title"
-//  mack.Dialog("Dialog text", "My Title", "default text")        // Display a dialog box with "default text" in the input field
-//  mack.Dialog("Dialog text", "My Title", "default text", "5")   // Display a dialog box that will disappear after 5 seconds
-//  mack.Dialog("Dialog text", "", "", "10")                      // Display a dialog box that will disappear after 10 seconds
-//  response, err := mack.Dialog("My dialog")                     // Capture the Response for the dialog box
+//
+//	mack.Dialog("Dialog text")                                    // Display a dialog box
+//	mack.Dialog("Dialog text", "My Title")                        // Display a dialog box with the title "My Title"
+//	mack.Dialog("Dialog text", "My Title", "default text")        // Display a dialog box with "default text" in the input field
+//	mack.Dialog("Dialog text", "My Title", "default text", "5")   // Display a dialog box that will disappear after 5 seconds
+//	mack.Dialog("Dialog text", "", "", "10")                      // Display a dialog box that will disappear after 10 seconds
+//	response, err := mack.Dialog("My dialog")                     // Capture the Response for the dialog box
 //
 // Parameters:
 //
-//  text string       // Required - The content of the dialog box
-//  title string      // Optional - The title of the dialog box, displayed in emphasis
-//  answer string     // Optional - The default text in the input field
-//  duration string   // Optional - The number of seconds to wait for a user response
+//	text string       // Required - The content of the dialog box
+//	title string      // Optional - The title of the dialog box, displayed in emphasis
+//	answer string     // Optional - The default text in the input field
+//	duration string   // Optional - The number of seconds to wait for a user response
 func Dialog(text string, options ...string) (Response, error) {
-  return runWithButtons(buildDialog(text, options))
+	return runWithButtons(buildDialog(text, options))
 }
 
 // Parse the dialog options and build the command
 func buildDialog(text string, options []string) string {
-  text = wrapInQuotes(text)
+	text = wrapInQuotes(text)
 
-  var title, answer, duration string
-  if len(options) > 0 && options[0] != "" {
-    title = "with title " + wrapInQuotes(options[0])
-  }
-  if len(options) > 1 && options[1] != "" {
-    answer = "default answer " + wrapInQuotes(options[1])
-  }
-  if len(options) > 2 && options[2] != "" {
-    duration = "giving up after " + options[2]
-  }
+	var title, answer, duration string
+	if len(options) > 0 && options[0] != "" {
+		title = "with title " + wrapInQuotes(options[0])
+	}
+	if len(options) > 1 && options[1] != "" {
+		answer = "default answer " + wrapInQuotes(options[1])
+	}
+	if len(options) > 2 && options[2] != "" {
+		duration = "giving up after " + options[2]
+	}
 
-  return build("display dialog", text, title, answer, duration)
+	return build("display dialog", text, title, answer, duration)
 }
 
 // DialogBox triggers a desktop dialog box with the option for custom buttons. Either an error is returned, or the string output from the user interaction.
-//  dialog := mack.DialogOptions{
-//    Text:           "Dialog text",          // Required
-//    Title:          "Dialog title",         // Optional
-//    Answer:         "Default answer",       // Optional
-//    Duration:       5,                      // Optional
-//    HiddenAnswer:   true,                   // Optional - If true, turns the input text to bullets
-//    Icon:           "stop",                 // Optional - "stop", "note", "caution" or location of .icns file
-//    Buttons:        "Yes, No, Don't Know",  // Optional - Comma separated list, max of 3
-//    DefaultButton:  "Don't Know",           // Optional - Ignored if no ButtonList
-//  }
-//  response, err := mack.DialogBox(dialog)   // Display a dialog with the DialogBox settings, returns an error and Response
+//
+//	dialog := mack.DialogOptions{
+//	  Text:           "Dialog text",          // Required
+//	  Title:          "Dialog title",         // Optional
+//	  Answer:         "Default answer",       // Optional
+//	  Duration:       5,                      // Optional
+//	  HiddenAnswer:   true,                   // Optional - If true, turns the input text to bullets
+//	  Icon:           "stop",                 // Optional - "stop", "note", "caution" or location of .icns file
+//	  Buttons:        "Yes, No, Don't Know",  // Optional - Comma separated list, max of 3
+//	  DefaultButton:  "Don't Know",           // Optional - Ignored if no ButtonList
+//	}
+//	response, err := mack.DialogBox(dialog)   // Display a dialog with the DialogBox settings, returns an error and Response
 func DialogBox(dialog DialogOptions) (Response, error) {
-  return runWithButtons(buildDialogBox(dialog))
+	return runWithButtons(buildDialogBox(dialog))
 }
 
 // Parse the DialogBox options and build the command
 func buildDialogBox(dialog DialogOptions) string {
-  var title, answer, hiddenAnswer, icon, duration, buttons, defaultButton string
-  text := wrapInQuotes(dialog.Text)
+	var title, answer, hiddenAnswer, icon, duration, buttons, defaultButton string
+	text := wrapInQuotes(dialog.Text)
 
-  if dialog.Title != "" {
-    title = "with title " + wrapInQuotes(dialog.Title)
-  }
-  if dialog.Answer != "" {
-    answer = "default answer " + wrapInQuotes(dialog.Answer)
-  }
-  if dialog.HiddenAnswer {
-    hiddenAnswer = "with hidden answer"
-  }
-  if dialog.Icon != "" {
-    if strings.Index(dialog.Icon, ".icns") > 0 {
-      // found a filepath to an icon
-      icon = "with icon " + wrapInQuotes(dialog.Icon)
-    } else {
-      // using a system icon
-      icon = "with icon " + dialog.Icon
-    }
-  }
-  if dialog.Duration > 0 {
-    duration = "giving up after " + strconv.Itoa(dialog.Duration)
-  }
-  if dialog.Buttons != "" {
-    buttons = makeButtonList(dialog.Buttons)
+	if dialog.Title != "" {
+		title = "with title " + wrapInQuotes(dialog.Title)
+	}
+	if dialog.Answer != "" {
+		answer = "default answer " + wrapInQuotes(dialog.Answer)
+	}
+	if dialog.HiddenAnswer {
+		hiddenAnswer = "with hidden answer"
+	}
+	if dialog.Icon != "" {
+		if strings.Index(dialog.Icon, ".icns") > 0 {
+			// found a filepath to an icon
+			icon = "with icon POSIX file " + wrapInQuotes(dialog.Icon)
+		} else {
+			// using a system icon
+			icon = "with icon " + dialog.Icon
+		}
+	}
+	if dialog.Duration > 0 {
+		duration = "giving up after " + strconv.Itoa(dialog.Duration)
+	}
+	if dialog.Buttons != "" {
+		buttons = makeButtonList(dialog.Buttons)
 
-    if dialog.DefaultButton != "" {
-      defaultButton = "default button " + wrapInQuotes(dialog.DefaultButton)
-    }
-  }
+		if dialog.DefaultButton != "" {
+			defaultButton = "default button " + wrapInQuotes(dialog.DefaultButton)
+		}
+	}
 
-  return build("display dialog", text, title, answer, hiddenAnswer, icon, duration, buttons, defaultButton)
+	return build("display dialog", text, title, answer, hiddenAnswer, icon, duration, buttons, defaultButton)
 }
 
 // DialogOptions are used to generate a DialogBox
 type DialogOptions struct {
-  Text string           // The content of the dialog box
-  Title string          // The title of the dialog box, displayed in emphasis
-  Answer string         // The default text in the input field
-  HiddenAnswer bool     // If true, converts the answer text to bullets (like a password field)
-  Icon string           // The path to a .icns file, or one of the following: "stop", "note", "caution"
-  Duration int          // The number of seconds to wait for a user response
+	Text         string // The content of the dialog box
+	Title        string // The title of the dialog box, displayed in emphasis
+	Answer       string // The default text in the input field
+	HiddenAnswer bool   // If true, converts the answer text to bullets (like a password field)
+	Icon         string // The path to a .icns file, or one of the following: "stop", "note", "caution"
+	Duration     int    // The number of seconds to wait for a user response
 
-  // Buttons
-  Buttons string        // The list of up to 3 buttons. Must be commas separated, ex. "Yes, No, Don't Know"
-  DefaultButton string  // The default selected button from the button list, ex. "Don't Know"
+	// Buttons
+	Buttons       string // The list of up to 3 buttons. Must be commas separated, ex. "Yes, No, Don't Know"
+	DefaultButton string // The default selected button from the button list, ex. "Don't Know"
 }

--- a/dialog_test.go
+++ b/dialog_test.go
@@ -1,146 +1,146 @@
 /*
 ** Mack: Alert Test
 ** Test desktop dialog boxes
-*/
+ */
 
 package mack
 
 import (
-  "testing"
+	"testing"
 )
 
 func TestBuildDialog(t *testing.T) {
-  stringAssertTests := []StringAssert{
-    StringAssert{
-      actual: buildDialog("text", []string{}),
-      expected: "display dialog \"text\"",
-    },
-    StringAssert{
-      actual: buildDialog("text", []string{"title"}),
-      expected: "display dialog \"text\" with title \"title\"",
-    },
-    StringAssert{
-      actual: buildDialog("text", []string{"title", "answer"}),
-      expected: "display dialog \"text\" with title \"title\" default answer \"answer\"",
-    },
-    StringAssert{
-      actual: buildDialog("text", []string{"title", "answer", "5"}),
-      expected: "display dialog \"text\" with title \"title\" default answer \"answer\" giving up after 5",
-    },
-    StringAssert{
-      actual: buildDialog("text", []string{"", "", "5"}),
-      expected: "display dialog \"text\" giving up after 5",
-    },
-  }
+	stringAssertTests := []StringAssert{
+		StringAssert{
+			actual:   buildDialog("text", []string{}),
+			expected: "display dialog \"text\"",
+		},
+		StringAssert{
+			actual:   buildDialog("text", []string{"title"}),
+			expected: "display dialog \"text\" with title \"title\"",
+		},
+		StringAssert{
+			actual:   buildDialog("text", []string{"title", "answer"}),
+			expected: "display dialog \"text\" with title \"title\" default answer \"answer\"",
+		},
+		StringAssert{
+			actual:   buildDialog("text", []string{"title", "answer", "5"}),
+			expected: "display dialog \"text\" with title \"title\" default answer \"answer\" giving up after 5",
+		},
+		StringAssert{
+			actual:   buildDialog("text", []string{"", "", "5"}),
+			expected: "display dialog \"text\" giving up after 5",
+		},
+	}
 
-  runStringAssertTests("buildDialog", stringAssertTests, t)
+	runStringAssertTests("buildDialog", stringAssertTests, t)
 }
 
 func TestBuildDialogBox(t *testing.T) {
-  stringAssertTests := []StringAssert{
-    StringAssert{
-      actual: buildDialogBox(DialogOptions{
-        Text: "text",
-      }),
-      expected: "display dialog \"text\"",
-    },
-    StringAssert{
-      actual: buildDialogBox(DialogOptions{
-        Text: "text",
-        Title: "title",
-      }),
-      expected: "display dialog \"text\" with title \"title\"",
-    },
-    StringAssert{
-      actual: buildDialogBox(DialogOptions{
-        Text: "text",
-        Title: "title",
-        Answer: "answer",
-      }),
-      expected: "display dialog \"text\" with title \"title\" default answer \"answer\"",
-    },
-    StringAssert{
-      actual: buildDialogBox(DialogOptions{
-        Text: "text",
-        Title: "title",
-        Answer: "answer",
-        HiddenAnswer: true,
-      }),
-      expected: "display dialog \"text\" with title \"title\" default answer \"answer\" with hidden answer",
-    },
-    StringAssert{
-      actual: buildDialogBox(DialogOptions{
-        Text: "text",
-        Title: "title",
-        Answer: "answer",
-        HiddenAnswer: false,
-        Icon: "my-icon.icns",
-      }),
-      expected: "display dialog \"text\" with title \"title\" default answer \"answer\" with icon \"my-icon.icns\"",
-    },
-    StringAssert{
-      actual: buildDialogBox(DialogOptions{
-        Text: "text",
-        Title: "title",
-        Answer: "answer",
-        HiddenAnswer: false,
-        Icon: "0",
-      }),
-      expected: "display dialog \"text\" with title \"title\" default answer \"answer\" with icon 0",
-    },
-    StringAssert{
-      actual: buildDialogBox(DialogOptions{
-        Text: "text",
-        Title: "title",
-        Answer: "answer",
-        HiddenAnswer: false,
-        Icon: "0",
-        Duration: 5,
-      }),
-      expected: "display dialog \"text\" with title \"title\" default answer \"answer\" with icon 0 giving up after 5",
-    },
-    StringAssert{
-      actual: buildDialogBox(DialogOptions{
-        Text: "text",
-        Title: "title",
-        Answer: "answer",
-        HiddenAnswer: false,
-        Icon: "0",
-        Duration: 5,
-        Buttons: "Yes, No, Don't Know",
-      }),
-      expected: "display dialog \"text\" with title \"title\" default answer \"answer\" with icon 0 giving up after 5 " +
-                "buttons {\"Yes\",\"No\",\"Don't Know\"}",
-    },
-    StringAssert{
-      actual: buildDialogBox(DialogOptions{
-        Text: "text",
-        Title: "title",
-        Answer: "answer",
-        HiddenAnswer: false,
-        Icon: "0",
-        Duration: 5,
-        Buttons: "Yes, No, Don't Know",
-        DefaultButton: "Don't Know",
-      }),
-      expected: "display dialog \"text\" with title \"title\" default answer \"answer\" with icon 0 giving up after 5 " +
-                "buttons {\"Yes\",\"No\",\"Don't Know\"} default button \"Don't Know\"",
-    },
-    StringAssert{
-      actual: buildDialogBox(DialogOptions{
-        Text: "text",
-        Title: "title",
-        Answer: "answer",
-        HiddenAnswer: false,
-        Icon: "0",
-        Duration: 5,
-        Buttons: "Yes, No, Don't Know, One Too Many",
-        DefaultButton: "Don't Know",
-      }),
-      expected: "display dialog \"text\" with title \"title\" default answer \"answer\" with icon 0 giving up after 5 " +
-                "buttons {\"Yes\",\"No\",\"Don't Know\"} default button \"Don't Know\"",
-    },
-  }
+	stringAssertTests := []StringAssert{
+		StringAssert{
+			actual: buildDialogBox(DialogOptions{
+				Text: "text",
+			}),
+			expected: "display dialog \"text\"",
+		},
+		StringAssert{
+			actual: buildDialogBox(DialogOptions{
+				Text:  "text",
+				Title: "title",
+			}),
+			expected: "display dialog \"text\" with title \"title\"",
+		},
+		StringAssert{
+			actual: buildDialogBox(DialogOptions{
+				Text:   "text",
+				Title:  "title",
+				Answer: "answer",
+			}),
+			expected: "display dialog \"text\" with title \"title\" default answer \"answer\"",
+		},
+		StringAssert{
+			actual: buildDialogBox(DialogOptions{
+				Text:         "text",
+				Title:        "title",
+				Answer:       "answer",
+				HiddenAnswer: true,
+			}),
+			expected: "display dialog \"text\" with title \"title\" default answer \"answer\" with hidden answer",
+		},
+		StringAssert{
+			actual: buildDialogBox(DialogOptions{
+				Text:         "text",
+				Title:        "title",
+				Answer:       "answer",
+				HiddenAnswer: false,
+				Icon:         "my-icon.icns",
+			}),
+			expected: "display dialog \"text\" with title \"title\" default answer \"answer\" with icon POSIX file \"my-icon.icns\"",
+		},
+		StringAssert{
+			actual: buildDialogBox(DialogOptions{
+				Text:         "text",
+				Title:        "title",
+				Answer:       "answer",
+				HiddenAnswer: false,
+				Icon:         "0",
+			}),
+			expected: "display dialog \"text\" with title \"title\" default answer \"answer\" with icon 0",
+		},
+		StringAssert{
+			actual: buildDialogBox(DialogOptions{
+				Text:         "text",
+				Title:        "title",
+				Answer:       "answer",
+				HiddenAnswer: false,
+				Icon:         "0",
+				Duration:     5,
+			}),
+			expected: "display dialog \"text\" with title \"title\" default answer \"answer\" with icon 0 giving up after 5",
+		},
+		StringAssert{
+			actual: buildDialogBox(DialogOptions{
+				Text:         "text",
+				Title:        "title",
+				Answer:       "answer",
+				HiddenAnswer: false,
+				Icon:         "0",
+				Duration:     5,
+				Buttons:      "Yes, No, Don't Know",
+			}),
+			expected: "display dialog \"text\" with title \"title\" default answer \"answer\" with icon 0 giving up after 5 " +
+				"buttons {\"Yes\",\"No\",\"Don't Know\"}",
+		},
+		StringAssert{
+			actual: buildDialogBox(DialogOptions{
+				Text:          "text",
+				Title:         "title",
+				Answer:        "answer",
+				HiddenAnswer:  false,
+				Icon:          "0",
+				Duration:      5,
+				Buttons:       "Yes, No, Don't Know",
+				DefaultButton: "Don't Know",
+			}),
+			expected: "display dialog \"text\" with title \"title\" default answer \"answer\" with icon 0 giving up after 5 " +
+				"buttons {\"Yes\",\"No\",\"Don't Know\"} default button \"Don't Know\"",
+		},
+		StringAssert{
+			actual: buildDialogBox(DialogOptions{
+				Text:          "text",
+				Title:         "title",
+				Answer:        "answer",
+				HiddenAnswer:  false,
+				Icon:          "0",
+				Duration:      5,
+				Buttons:       "Yes, No, Don't Know, One Too Many",
+				DefaultButton: "Don't Know",
+			}),
+			expected: "display dialog \"text\" with title \"title\" default answer \"answer\" with icon 0 giving up after 5 " +
+				"buttons {\"Yes\",\"No\",\"Don't Know\"} default button \"Don't Know\"",
+		},
+	}
 
-  runStringAssertTests("buildDialogBox", stringAssertTests, t)
+	runStringAssertTests("buildDialogBox", stringAssertTests, t)
 }


### PR DESCRIPTION
stumbled on an issue with supplying a local path to an icon file, where this error occurs:

```
exit status 1: 0:85: execution error: A resource wasn’t found. (-192) (display dialog "time's up!" with title "5s timer" with icon "./assets/clock_red.icns")
```

ultimately, the error occurs because applescript seems to expect files to be referenced by [colon-delimited paths](https://developer.apple.com/library/archive/documentation/LanguagesUtilities/Conceptual/MacAutomationScriptingGuide/ReferenceFilesandFolders.html), otherwise known as a Hierarchical File System (HFS) path. you can tell applescript the path is POSIX format by adding the directive `POSIX path` before the file path is provided.

sorry for the very noisy diff - gofmt insisted on changing all the spaces to tabs. the specific change I am hoping to contribute here is found on [line 84 here](https://github.com/cwinters8/mack/blob/master/dialog.go#L84). if you'd like I can restore the original files and make the necessary changes with formatOnSave disabled [as described here](https://github.com/golang/vscode-go/issues/2179), because apparently there is currently no way to modify gofmt's behavior when used with the VS code extension.

the [corresponding test](https://github.com/cwinters8/mack/blob/master/dialog_test.go#L79) is also updated, with similar space -> tab conversions by gofmt unfortunately.

I'm also wondering if this should be implemented in a more conditional manner, maybe with some special handling depending on if the dialog.Icon path is detected as POSIX or HFS format? I could add that logic as well if it would be helpful. the reason I did not implement that logic already is because I find it doubtful that most people will specify paths in HFS format, but I could definitely be wrong.

thanks for reviewing this!